### PR TITLE
added kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "A system information tool for Rustaceans"
 readme = "README.md"
 repository = "https://github.com/irevenko/ferris-fetch/"
 license = "MIT"
-license-file = "LICENSE"
 keywords = ["system", "cli"]
 publish = true
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,14 +15,13 @@ const FERRIS_ART: &str = r###"
   ▀▓▓▄ ▀▄ ▀▓▓▀▓▀▒▓▓▓▒▀▓▒▓▓▀▒▓▓▓▒▀▓▀▓▒▓▀  ▀ ▐▓▀
     ▓▄  ▄  ▀▓▓▓▓▓▀▀▀         ▓▓▓▓▓▀    ▀ ▄▓
       ▀       ▀▓▓▓▓▄▄     ▄▄▓▓▓▀         ▀
-                 ▀▀▀▀     ▀▀▀                                        
+                 ▀▀▀▀     ▀▀▀             
 "###;
 
 fn exc(exc: &str) -> Result<std::process::Output, std::io::Error> {
     let exc: Vec<&str> = exc.split_whitespace().collect();
     let mut cmd = std::process::Command::new(exc[0]);
-    cmd.args(&exc[1..exc.len()])
-        .output()
+    cmd.args(&exc[1..exc.len()]).output()
 }
 
 fn get_ver(cmd: &str) -> String {
@@ -30,9 +29,7 @@ fn get_ver(cmd: &str) -> String {
         Ok(ver) => ver.stdout,
         Err(_) => "not present".as_bytes().to_vec(),
     };
-    let mut get_ver = std::str::from_utf8(&get_ver)
-        .unwrap()
-        .lines();
+    let mut get_ver = std::str::from_utf8(&get_ver).unwrap().lines();
     match get_ver.next() {
         Some(v) => v.to_string(),
         None => "not present.".to_string(),
@@ -44,70 +41,117 @@ fn get_cargo_packages() -> String {
         Ok(installs) => installs.stdout,
         Err(_) => "not present".as_bytes().to_vec(),
     };
-    let cargo_installs = std::str::from_utf8(&cargo_installs)
-        .unwrap()
-        .lines();
-    String::from(format!("{}", cargo_installs.count() / 2))
+    let cargo_installs = std::str::from_utf8(&cargo_installs).unwrap().lines();
+    format!("{}", cargo_installs.count() / 2)
+}
+
+fn get_kernel() -> Option<String> {
+    System::new().get_kernel_version()
 }
 
 fn render(info: Vec<String>) {
-    let mut lines = FERRIS_ART.lines();
+    let lines = FERRIS_ART.lines();
     let mut i = 0;
     let empty = String::from("");
-    loop {
-        match lines.next() {
-            Some(line) => {
-                println!("{}{}", 
-                         line.red(), 
-                         match i <= info.len() - 1 {
-                             true => {
-                                 i = i + 1;
-                                 &info[i - 1]
-                             },
-                             false => &empty,
-                        });
-            },
-            None => break,
-        }
+    for line in lines {
+        println!(
+            "{}{}",
+            line.red(),
+            match i < info.len() {
+                true => {
+                    i += 1;
+                    &info[i - 1]
+                }
+                false => &empty,
+            }
+        );
     }
 }
 
-
 fn main() {
-	let mut info: Vec<String> = vec![];
+    let mut info: Vec<String> = vec![];
 
-	let cpu_sys = System::new();
-	let cpu = cpu_sys.get_processors();
-	let cpu = cpu[0].get_brand();
+    let cpu_sys = System::new();
+    let cpu = cpu_sys.get_processors();
+    let cpu = cpu[0].get_brand();
 
-	let mut ram_sys = sysinfo::System::new_all();
-	let used_ram = ram_sys.get_used_memory() / 1024;
-	let total_ram = ram_sys.get_total_memory() / 1024;
-	ram_sys.refresh_all();
+    let mut ram_sys = sysinfo::System::new_all();
+    let used_ram = ram_sys.get_used_memory() / 1024;
+    let total_ram = ram_sys.get_total_memory() / 1024;
+    ram_sys.refresh_all();
 
-	let rustc_cmd = get_ver("rustc -V");
-	let cargo_cmd = get_ver("cargo -V");
-	let rustup_cmd = get_ver("rustup -V");
-	let rust_ver: Vec<&str> = rustc_cmd.split_whitespace().collect();
-	let cargo_ver: Vec<&str> = cargo_cmd.split_whitespace().collect();
-	let rustup_ver: Vec<&str> = rustup_cmd.split_whitespace().collect();
-	let cargo_packages = get_cargo_packages();
+    let rustc_cmd = get_ver("rustc -V");
+    let cargo_cmd = get_ver("cargo -V");
+    let rustup_cmd = get_ver("rustup -V");
+    let rust_ver: Vec<&str> = rustc_cmd.split_whitespace().collect();
+    let cargo_ver: Vec<&str> = cargo_cmd.split_whitespace().collect();
+    let rustup_ver: Vec<&str> = rustup_cmd.split_whitespace().collect();
+    let cargo_packages = get_cargo_packages();
 
-	// hell formatting (because of the crab shape)
-	info.push("".to_string());
-	info.push("".to_string());
-	info.push(format!("              {}{}{}", whoami::username().bright_red().bold(), "@".bold(), whoami::hostname().bright_red().bold()));
-	info.push(format!("              {}", "════════════════"));
-	info.push(format!("          {}{}","rust ver: ".bright_red(), rust_ver[1]));
-	info.push(format!("        {}{}","rustup ver: ".bright_red(), rustup_ver[1]));
-	info.push(format!("        {}{}","cargo ver: ".bright_red(), cargo_ver[1]));
-	info.push(format!("      {}{}","cargo packages: ".bright_red(), cargo_packages));
-	info.push(format!("	  {}{}","os: ".bright_red(), whoami::distro()));
-	info.push(format!("	  {}{}","cpu: ".bright_red(), cpu));
-	info.push(format!("	  {}{} » {} MB","ram: ".bright_red(), used_ram, total_ram));
-	info.push("".to_string());
-	info.push(format!("	  {}{}{}{}{}{}{}{}", "███".bright_red(), "███".bright_yellow(), "███".bright_green(), "███".bright_cyan(), "███".bright_blue(), "███".bright_magenta(), "███".bright_black(), "███".bright_white()));
-	info.push(format!("	  {}{}{}{}{}{}{}{}", "███".red(), "███".yellow(), "███".green(), "███".cyan(), "███".blue(), "███".magenta(), "███".black(), "███".white()));
+    // hell formatting (because of the crab shape)
+    info.push("".to_string());
+    info.push("".to_string());
+    info.push(format!(
+        "              {}{}{}",
+        whoami::username().bright_red().bold(),
+        "@".bold(),
+        whoami::hostname().bright_red().bold()
+    ));
+    info.push(format!("              {}", "════════════════"));
+    info.push(format!(
+        "          {}{}",
+        "rust ver: ".bright_red(),
+        rust_ver[1]
+    ));
+    info.push(format!(
+        "        {}{}",
+        "rustup ver: ".bright_red(),
+        rustup_ver[1]
+    ));
+    info.push(format!(
+        "        {}{}",
+        "cargo ver: ".bright_red(),
+        cargo_ver[1]
+    ));
+    info.push(format!(
+        "      {}{}",
+        "cargo packages: ".bright_red(),
+        cargo_packages
+    ));
+    info.push(format!("	  {}{}", "os: ".bright_red(), whoami::distro()));
+    if let Some(kernel) = get_kernel() {
+        info.push(format!("	  {}{}", "kernel: ".bright_red(), kernel));
+    }
+    info.push(format!("	  {}{}", "cpu: ".bright_red(), cpu));
+    info.push(format!(
+        "	  {}{} » {} MB",
+        "ram: ".bright_red(),
+        used_ram,
+        total_ram
+    ));
+    info.push("".to_string());
+    info.push(format!(
+        "	  {}{}{}{}{}{}{}{}",
+        "███".bright_red(),
+        "███".bright_yellow(),
+        "███".bright_green(),
+        "███".bright_cyan(),
+        "███".bright_blue(),
+        "███".bright_magenta(),
+        "███".bright_black(),
+        "███".bright_white()
+    ));
+    info.push(format!(
+        "	  {}{}{}{}{}{}{}{}",
+        "███".red(),
+        "███".yellow(),
+        "███".green(),
+        "███".cyan(),
+        "███".blue(),
+        "███".magenta(),
+        "███".black(),
+        "███".white()
+    ));
 
-	render(info);
+    render(info);
 }


### PR DESCRIPTION
- ferris-fetch now shows the used kernel
- removed license-file in Cargo.toml to avoid `warning: only one of 'license' or 'license-file' is necessary`
- used `cargo clippy`
- formatted with `cargo fmt`