### PR TITLE
option: No ferris output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,13 +47,25 @@ fn get_cargo_crates() -> usize {
         })
 }
 
-fn render(info: &[String]) {
-    for (ferris_line, info_line) in FERRIS_ART.iter().zip(info) {
-        println!("{}   {}", ferris_line.red(), info_line);
+fn render(art: bool, info: &[String]) {
+    if art {
+        for (ferris_line, info_line) in FERRIS_ART.iter().zip(info) {
+            println!("{}   {}", ferris_line.red(), info_line);
+        }
+    } else {
+        for line in info {
+            println!("{}", line);
+        }
     }
 }
 
 fn main() {
+    let mut art = true;
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() == 2 && args[1] == "-s" {
+        art = false;
+    }
+
     let sys = System::new_with_specifics(RefreshKind::new().with_cpu().with_memory());
     let cpu = sys.get_processors()[0].get_brand();
     let kernel = sys.get_kernel_version().unwrap_or_else(|| "Unknown".into());
@@ -110,22 +122,25 @@ fn main() {
         "███".white()
     );
 
-    render(&[
-        "".to_string(),
-        "".to_string(),
-        userinfo,
-        splitline,
-        rustc_ver,
-        rustup_ver,
-        cargo_ver,
-        cargo_crates,
-        os,
-        kernel,
-        cpu,
-        ram,
-        "".to_string(),
-        bright_colors,
-        dark_colors,
-        "".to_string(),
-    ]);
+    render(
+        art,
+        &[
+            "".to_string(),
+            "".to_string(),
+            userinfo,
+            splitline,
+            rustc_ver,
+            rustup_ver,
+            cargo_ver,
+            cargo_crates,
+            os,
+            kernel,
+            cpu,
+            ram,
+            "".to_string(),
+            bright_colors,
+            dark_colors,
+            "".to_string(),
+        ],
+    );
 }


### PR DESCRIPTION
Hi,
This PR adds "no ferris" output for when we need to just copy & paste Rust information such as to create a bug report.

```
λ ferris-fetch -s


kyohei@archlinux
════════════════
rustc  ver: 1.60.0
rustup ver: 1.24.3
cargo  ver: 1.60.0
cargo crates: 24
os: Arch Linux
kernel: 5.17.5-arch1-1
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
ram: 2599 » 16313 MB
```

![2022-04-30_05-23](https://user-images.githubusercontent.com/61998590/166064185-04616008-2986-4839-a972-21ede6bf97bd.png)

In addtion to this, refactoerd & formatted some lines according to rust-analyzer(clippy).
Could you please review? Thank you.